### PR TITLE
Update composer.json for Laravel v12.0 [support for illuminate/contracts conflicts]

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^7.2|^8.0",
         "spatie/laravel-package-tools": "^1.16",
-        "illuminate/contracts": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0",
+        "illuminate/contracts": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0",
         "guzzlehttp/guzzle": "^7.2"
     },
     "require-dev": {


### PR DESCRIPTION
I've fixed the bug for not supporting Laravel v12.0. Here is the pull request. Please review the changes and if there is no issue, update the package.