### PR TITLE
Add support for custom configuration via withConfig() method

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,22 @@ private function processPayload($payload)
 }
 ```
 
+### 6. Using Custom Config
+
+If you don’t want to rely on .env or you’re building a SaaS application with multiple Steadfast Courier integrations, you can provide custom configuration using the withConfig method:
+
+```php
+use SteadFast\SteadFastCourierLaravelPackage\Facades\SteadfastCourier;
+
+// Set custom API credentials and optional base URL
+$response = SteadfastCourier::withConfig(
+    'your_api_key',          // API Key
+    'your_secret_key',       // API Secret
+    'optional_base_url'      // Optional: custom base URL
+)->getCurrentBalance();
+
+```
+
 ## 📞 Support
 For any issues or questions related to this package, please open an issue on GitHub.
 

--- a/src/SteadfastCourier.php
+++ b/src/SteadfastCourier.php
@@ -18,6 +18,15 @@ class SteadfastCourier
         $this->secretKey = config('steadfast-courier.secret_key');
     }
 
+    public function withConfig(string $apiKey, string $secretKey, ?string $baseUrl = null): self
+    {
+        $this->apiKey = $apiKey;
+        $this->secretKey = $secretKey;
+        $this->baseUrl = $baseUrl ?? $this->baseUrl;
+
+        return $this;
+    }
+
     public function placeOrder($data)
     {
         $response = Http::withHeaders([


### PR DESCRIPTION
### What does this PR do?

  - Adds withConfig() method to allow overriding default .env settings at runtime.
  - Useful for multi-business or multi-account setups.
  - Updates documentation with usage examples for getCurrentBalance() and other methods.

### Why is this needed?

  - Some users may not want to maintain .env values for API credentials.
  - SaaS applications often require multiple Steadfast Courier integrations.
  - Makes the package more flexible and developer-friendly.

### Notes

  - All existing functionality remains unchanged.
  - Documentation updated in README.md under Custom Config section.